### PR TITLE
modified card/img styling

### DIFF
--- a/about.html
+++ b/about.html
@@ -66,7 +66,10 @@
     <hr />
     <div class="container my-5">
       <h2 class="my-4 text-center">Our Team:</h2>
-      <div class="row row-cols-1 row-cols-md-2 g-2" style="height: 600px">
+      <div
+        class="row row-cols-1 row-cols-md-2 row-cols-xl-4 g-2"
+        style="height: 600px"
+      >
         <div class="col">
           <div class="card">
             <img

--- a/css/styles.css
+++ b/css/styles.css
@@ -30,7 +30,6 @@
 }
 
 .card-img-top {
-    /* max-height: 340px; */
     object-fit: cover;
     width: 100%;
     aspect-ratio: 1 / 1;
@@ -41,8 +40,6 @@
     margin: 0;
     padding: 0;
 }
-
-/* 768 */
 
 @media screen and (max-width: 768px) {
     .rounded-start {

--- a/css/styles.css
+++ b/css/styles.css
@@ -14,3 +14,39 @@
     width: 100%;
     background-color: rgba(0, 0, 0, 0.3);
 }
+
+.img-fluid {
+    width: 100%;
+    height: 100%;
+    min-height: 134px;
+    object-fit: cover;
+    padding: 0;
+    margin: 0;
+}
+
+.card {
+    max-width: 500px;
+    min-height: 420px;
+}
+
+.card-img-top {
+    /* max-height: 340px; */
+    object-fit: cover;
+    width: 100%;
+    aspect-ratio: 1 / 1;
+}
+
+.col-md-4 {
+    height: 100%;
+    margin: 0;
+    padding: 0;
+}
+
+/* 768 */
+
+@media screen and (max-width: 768px) {
+    .rounded-start {
+        border-bottom-left-radius: 0 !important;
+        border-top-right-radius: var(--bs-border-radius) !important;
+    }
+}


### PR DESCRIPTION
Product Image Styling:
I noticed that the border radius on the image wasn't changing when the card styling shifted at the small breakpoint. At medium and larger, the card is rendered with the image on the left, so both left corners are rounded. However, when the styling shifts for the image to be at the top of the card, the bottom left corner remained rounded and the top right un-rounded. I modified the styling with a media query so that the correct corners are rounded.

About Us Card/Image Styling:
I set the container to have four columns beginning at the xl breakpoint, to prevent the cards from being too large. Additionally, I set an aspect ratio on the images to maintain a perfect square and changed object-fit to cover to prevent image stretching.